### PR TITLE
Fix/scrolling on a rotated ScrollingContainer

### DIFF
--- a/src/ScrollingContainer.js
+++ b/src/ScrollingContainer.js
@@ -269,7 +269,10 @@ ScrollingContainer.prototype.initScrolling = function () {
 
     //Drag scroll
     if (this.dragScrolling) {
+        this._localOffset = new PIXI.Point();
+
         var drag = new DragEvent(this);
+
         drag.onDragStart = function (e) {
             if (!this.scrolling) {
                 containerStart.copy(container.position);
@@ -281,12 +284,12 @@ ScrollingContainer.prototype.initScrolling = function () {
         };
 
         drag.onDragMove = function (e, offset) {
-            const localOffset = localizeVector(this.innerContainer, offset);
+            localizeVector(this.innerContainer, offset, this._localOffset);
 
             if (this.scrollX)
-                targetPosition.x = containerStart.x + localOffset.x;
+                targetPosition.x = containerStart.x + this._localOffset.x;
             if (this.scrollY)
-                targetPosition.y = containerStart.y + localOffset.y;
+                targetPosition.y = containerStart.y + this._localOffset.y;
         };
 
         drag.onDragEnd = function (e) {

--- a/src/ScrollingContainer.js
+++ b/src/ScrollingContainer.js
@@ -3,7 +3,8 @@ var UIBase = require('./UIBase'),
     MathHelper = require('./MathHelper'),
     Ticker = require('./Ticker'),
     DragEvent = require('./Interaction/DragEvent'),
-    MouseScrollEvent = require('./Interaction/MouseScrollEvent');
+    MouseScrollEvent = require('./Interaction/MouseScrollEvent'),
+    localizeVector = require('./Utils/LocalizeVector');
 
 
 /**
@@ -280,10 +281,12 @@ ScrollingContainer.prototype.initScrolling = function () {
         };
 
         drag.onDragMove = function (e, offset) {
+            const localOffset = localizeVector(this.innerContainer, offset);
+
             if (this.scrollX)
-                targetPosition.x = containerStart.x + offset.x;
+                targetPosition.x = containerStart.x + localOffset.x;
             if (this.scrollY)
-                targetPosition.y = containerStart.y + offset.y;
+                targetPosition.y = containerStart.y + localOffset.y;
         };
 
         drag.onDragEnd = function (e) {

--- a/src/ScrollingContainer.js
+++ b/src/ScrollingContainer.js
@@ -136,6 +136,7 @@ ScrollingContainer.prototype.initScrolling = function () {
         lastPosition = new PIXI.Point(),
         Position = new PIXI.Point(),
         Speed = new PIXI.Point(),
+        localOffset = new PIXI.Point();
         stop,
         self = this;
 
@@ -269,8 +270,6 @@ ScrollingContainer.prototype.initScrolling = function () {
 
     //Drag scroll
     if (this.dragScrolling) {
-        this._localOffset = new PIXI.Point();
-
         var drag = new DragEvent(this);
 
         drag.onDragStart = function (e) {
@@ -284,12 +283,12 @@ ScrollingContainer.prototype.initScrolling = function () {
         };
 
         drag.onDragMove = function (e, offset) {
-            localizeVector(this.innerContainer, offset, this._localOffset);
+            localizeVector(this.innerContainer, offset, localOffset);
 
             if (this.scrollX)
-                targetPosition.x = containerStart.x + this._localOffset.x;
+                targetPosition.x = containerStart.x + localOffset.x;
             if (this.scrollY)
-                targetPosition.y = containerStart.y + this._localOffset.y;
+                targetPosition.y = containerStart.y + localOffset.y;
         };
 
         drag.onDragEnd = function (e) {

--- a/src/Utils/LocalizeVector.js
+++ b/src/Utils/LocalizeVector.js
@@ -1,10 +1,14 @@
-function localizeVector(localDisplayObject, globalVector) {
-    const globalPosition = localDisplayObject.getGlobalPosition();
-    const globalPoint = {
-        x: globalVector.x + globalPosition.x,
-        y: globalVector.y + globalPosition.y
-    };
-    return localDisplayObject.toLocal(globalPoint);
+const from = undefined,
+      skipUpdate = true;
+
+var globalPoint = new PIXI.Point();
+
+function localizeVector(localDisplayObject, globalVector, localVector) {
+    localDisplayObject.getGlobalPosition(globalPoint);
+    globalPoint.x += globalVector.x;
+    globalPoint.y += globalVector.y;
+
+    return localDisplayObject.toLocal(globalPoint, from, localVector, skipUpdate);
 }
 
 module.exports = localizeVector;

--- a/src/Utils/LocalizeVector.js
+++ b/src/Utils/LocalizeVector.js
@@ -1,0 +1,10 @@
+function localizeVector(localDisplayObject, globalVector) {
+    const globalPosition = localDisplayObject.getGlobalPosition();
+    const globalPoint = {
+        x: globalVector.x + globalPosition.x,
+        y: globalVector.y + globalPosition.y
+    };
+    return localDisplayObject.toLocal(globalPoint);
+}
+
+module.exports = localizeVector;


### PR DESCRIPTION
The original problem was that rotating the phone 90 degrees made the X, Y coordinates for dragging a scrollable area swap. The screen/game was rotated, but the drag events weren't.

This fixes the problem with scrolling on a rotated ScrollingContainer.
Now the offset vector is transformed o local space (rotated and scaled) so it works as expected.